### PR TITLE
Fix: redirect to home after login success 

### DIFF
--- a/frontend/src/pages/Auth/Signin/index.js
+++ b/frontend/src/pages/Auth/Signin/index.js
@@ -45,7 +45,9 @@ function Signin({ history }) {
           password: values.password,
         });
         login(loginResponse);
-        history.push("/profile");
+        // chuyển về home sau khi login
+        window.location.href = "/";
+
       } catch (e) {
         bag.setErrors({ general: e.response.data.message });
       }


### PR DESCRIPTION
Sửa lỗi không chuyển trang sau khi đăng nhập.
Thay history.push("/profile") bằng window.location.href = "/"